### PR TITLE
History State Inconsistency Fixes

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { FocusStyleManager } from '@blueprintjs/core';
-import { GraphLayout, GraphEditor, GraphConfig, GraphContext } from '@alephdata/vislib';
+import { GraphLayout, GraphEditor, GraphConfig, GraphContext, Viewport } from '@alephdata/vislib';
 import { defaultModel, Model} from '@alephdata/followthemoney'
 import {ToolBox} from "./components/ToolBox";
 
@@ -13,40 +13,60 @@ FocusStyleManager.onlyShowFocusOnTabs();
 
 const model = new Model(defaultModel)
 const config = new GraphConfig()
-const demoKey = 'LS_v1'
+const demoKeyLayout = 'LSL_v1'
+const demoKeyViewport = 'LSV_v1'
 
 interface IVisState {
-  layout: GraphLayout
+  layout: GraphLayout,
+  viewport: Viewport
 }
 
 export default class Vis2 extends React.Component {
   state: IVisState = {
-    layout: new GraphLayout(config, model)
+    layout: new GraphLayout(config, model),
+    viewport: new Viewport(config)
+
   }
   saveTimeout: any
 
   constructor(props: any) {
     super(props)
-    const jsonLayout = localStorage.getItem(demoKey);
+    const jsonLayout = localStorage.getItem(demoKeyLayout);
+    const jsonViewport = localStorage.getItem(demoKeyViewport);
     if (jsonLayout) {
       this.state.layout = GraphLayout.fromJSON(config, model, JSON.parse(jsonLayout))
       this.state.layout.history.push(this.state.layout.toJSON());
     }
+    if (jsonViewport) {
+      this.state.viewport = Viewport.fromJSON(config, JSON.parse(jsonViewport))
+    }
+
     this.updateLayout = this.updateLayout.bind(this)
+    this.updateViewport = this.updateViewport.bind(this)
   }
 
   updateLayout(layout: GraphLayout) {
     this.setState({layout})
     clearTimeout(this.saveTimeout)
     this.saveTimeout = setTimeout(() => {
-      localStorage.setItem(demoKey, JSON.stringify(layout.toJSON()))
+      localStorage.setItem(demoKeyLayout, JSON.stringify(layout.toJSON()))
+    }, 1000)
+  }
+
+  updateViewport(viewport: Viewport) {
+    this.setState({viewport})
+    clearTimeout(this.saveTimeout)
+    this.saveTimeout = setTimeout(() => {
+      localStorage.setItem(demoKeyViewport, JSON.stringify(viewport.toJSON()))
     }, 1000)
   }
 
   render() {
     const layoutContext = {
       layout:this.state.layout,
-      updateLayout:this.updateLayout
+      updateLayout:this.updateLayout,
+      viewport: this.state.viewport,
+      updateViewport:this.updateViewport
     }
     return <GraphContext.Provider value={layoutContext}>
       <GraphEditor

--- a/app/src/components/ToolBox.tsx
+++ b/app/src/components/ToolBox.tsx
@@ -8,7 +8,7 @@ import {ToolUpload} from "./ToolUpload";
 interface IToolBoxProps extends IGraphContext {};
 
 
-export function ToolBox({layout, updateLayout}:IToolBoxProps){
+export function ToolBox({layout, updateLayout, viewport, updateViewport}:IToolBoxProps){
   return (<>
     <Divider/>
     <Tooltip content="Align horizontal">
@@ -43,6 +43,8 @@ export function ToolBox({layout, updateLayout}:IToolBoxProps){
     <ToolUpload
       layout={layout}
       updateLayout={updateLayout}
+      viewport={viewport}
+      updateViewport={updateViewport}
     />
     <Tooltip content="Download data">
       <AnchorButton download icon="cloud-download" onMouseDown={(e) => {

--- a/lib/src/GraphContext.ts
+++ b/lib/src/GraphContext.ts
@@ -1,11 +1,14 @@
 import * as React from 'react'
-import { GraphLayout } from "./layout";
+import { GraphLayout, Viewport } from "./layout";
 
 export type GraphUpdateHandler = (graph: GraphLayout) => void
+export type ViewportUpdateHandler = (viewport: Viewport) => void
 
 export interface IGraphContext {
   layout: GraphLayout,
-  updateLayout: GraphUpdateHandler
+  updateLayout: GraphUpdateHandler,
+  viewport: Viewport,
+  updateViewport: ViewportUpdateHandler
 }
 
 export const GraphContext = React.createContext<IGraphContext | undefined>(undefined)

--- a/lib/src/GraphEditor.tsx
+++ b/lib/src/GraphEditor.tsx
@@ -16,15 +16,13 @@ export class GraphEditor extends React.Component<IGraphEditorProps> {
   }
 
   onZoom(factor: number) {
-    const {layout, updateLayout} = this.props
-    const {viewport} = layout
+    const {viewport, updateViewport} = this.props
     const newZoomLevel = viewport.zoomLevel * factor
-    layout.viewport = viewport.setZoom(newZoomLevel)
-    updateLayout(layout)
+    updateViewport(viewport.setZoom(newZoomLevel))
   }
 
   render() {
-    const { layout, updateLayout } = this.props
+    const { layout, updateLayout, viewport, updateViewport } = this.props
     const config = layout.config
     return (
       <div style={{flex: 1, display: 'flex', flexFlow: 'column', height: '100%'}} >
@@ -32,6 +30,8 @@ export class GraphEditor extends React.Component<IGraphEditorProps> {
           <Toolbar
             layout={layout}
             updateLayout={updateLayout}
+            viewport={viewport}
+            updateViewport={updateViewport}
             {...this.props.toolbarProps}
           />
         </div>
@@ -43,7 +43,7 @@ export class GraphEditor extends React.Component<IGraphEditorProps> {
                 <Button icon="zoom-out" onClick={() => this.onZoom(1.2)}/>
               </ButtonGroup>
             </div>
-            <GraphRenderer layout={layout} updateLayout={updateLayout}/>
+            <GraphRenderer layout={layout} updateLayout={updateLayout} viewport={viewport} updateViewport={updateViewport}/>
           </div>
           <div style={{
             flexGrow: 1,
@@ -57,7 +57,7 @@ export class GraphEditor extends React.Component<IGraphEditorProps> {
             borderLeftColor: config.BORDER_COLOR,
             padding: config.contentPadding
           }}>
-            <Sidebar layout={layout} updateLayout={updateLayout}/>
+            <Sidebar layout={layout} updateLayout={updateLayout} viewport={viewport} updateViewport={updateViewport}/>
           </div>
         </div>
       </div>

--- a/lib/src/Toolbar.tsx
+++ b/lib/src/Toolbar.tsx
@@ -49,13 +49,12 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
   }
 
   onFitToSelection() {
-    const {layout, updateLayout} = this.props
+    const {layout, updateLayout, viewport, updateViewport} = this.props
     const selection = layout.getSelectedVertices()
     const vertices = selection.length > 0 ? selection : layout.getVertices()
     const points = vertices.filter((v) => !v.isHidden()).map((v) => v.position)
     const rect = Rectangle.fromPoints(...points)
-    layout.viewport = layout.viewport.fitToRect(rect)
-    updateLayout(layout)
+    updateViewport(viewport.fitToRect(rect))
   }
 
   onChangeSearch(event: React.FormEvent<HTMLInputElement>) {
@@ -94,7 +93,7 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
   }
 
   render() {
-    const { layout } = this.props
+    const { layout, viewport } = this.props
     const vertices = this.props.layout.getSelectedVertices()
     const hasSelection = layout.hasSelection()
     const canAddEdge = vertices.length > 0 && vertices.length <= 2
@@ -144,6 +143,8 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
         isOpen={this.state.edgeCreateOpen}
         toggleDialog={this.toggleAddEdge}
         updateLayout={this.props.updateLayout}
+        viewport={viewport}
+        updateViewport={this.props.updateViewport}
       />
     </React.Fragment>
   }

--- a/lib/src/editor/EdgeCreateDialog.tsx
+++ b/lib/src/editor/EdgeCreateDialog.tsx
@@ -79,7 +79,7 @@ export class EdgeCreateDialog extends React.Component<IEdgeCreateDialogProps, IE
   }
 
   onSubmit(e: React.ChangeEvent<HTMLFormElement>) {
-    const { layout, updateLayout, toggleDialog } = this.props
+    const { layout, viewport, updateLayout, updateViewport, toggleDialog } = this.props
     const { source, target, type } = this.state
     e.preventDefault()
     if (source && target && type && this.isValid()) {
@@ -91,7 +91,7 @@ export class EdgeCreateDialog extends React.Component<IEdgeCreateDialogProps, IE
         layout.addEntity(sourceEntity)
         const edge = Edge.fromValue(layout, type.property, source, target)
         layout.selectElement(edge)
-        layout.viewport = layout.viewport.setCenter(edge.getCenter())
+        updateViewport(viewport.setCenter(edge.getCenter()))
       }
       if (type.schema && type.schema.edge && sourceEntity && targetEntity) {
         const entity = layout.model.createEntity(type.schema)
@@ -100,7 +100,7 @@ export class EdgeCreateDialog extends React.Component<IEdgeCreateDialogProps, IE
         layout.addEntity(entity)
         const edge = Edge.fromEntity(layout, entity, source, target)
         layout.selectElement(edge)
-        layout.viewport = layout.viewport.setCenter(edge.getCenter())
+        updateViewport(viewport.setCenter(edge.getCenter()))
       }
       updateLayout(layout)
       toggleDialog()

--- a/lib/src/editor/VertexCreateDialog.tsx
+++ b/lib/src/editor/VertexCreateDialog.tsx
@@ -45,7 +45,7 @@ export class VertexCreateDialog extends React.Component<IVertexCreateDialogProps
   onSubmit(e: React.ChangeEvent<HTMLFormElement>) {
     const { label } = this.state
     const schema = this.getSchema()
-    const { layout, updateLayout } = this.context as IGraphContext
+    const { layout, updateLayout, viewport, updateViewport } = this.context as IGraphContext
     e.preventDefault()
     if (this.checkValid()) {
       const entity = layout.model.createEntity(schema)
@@ -55,8 +55,8 @@ export class VertexCreateDialog extends React.Component<IVertexCreateDialogProps
       const vertex = layout.getVertexByEntity(entity)
       if (vertex) {
         layout.selectElement(vertex)
-        layout.viewport = layout.viewport.setCenter(vertex.position)
         updateLayout(layout)
+        updateViewport(viewport.setCenter(vertex.position))
         this.setState({label: ''})
         this.props.toggleDialog()
       }

--- a/lib/src/layout/GraphLayout.ts
+++ b/lib/src/layout/GraphLayout.ts
@@ -113,7 +113,7 @@ export class GraphLayout {
 
   addEntity(entity: Entity) {
     this.entities.set(entity.id, entity)
-    this.generate()
+    this.layout()
     this.history.push(this.toJSON())
   }
 

--- a/lib/src/layout/GraphLayout.ts
+++ b/lib/src/layout/GraphLayout.ts
@@ -31,6 +31,7 @@ export class GraphLayout {
   selection = new Array<string>()
   selectionMode: boolean = true
   history: History;
+  private hasDraggedSelection = false
 
   constructor(config: GraphConfig, model: Model) {
     this.config = config
@@ -197,13 +198,17 @@ export class GraphLayout {
       const position = vertex.position.addition(offset)
       this.vertices.set(vertex.id, vertex.setPosition(position))
     })
+    this.hasDraggedSelection = true
   }
 
   dropSelection() {
     this.getSelectedVertices().forEach((vertex) => {
       this.vertices.set(vertex.id, vertex.snapPosition(vertex.position))
     });
-    this.history.push(this.toJSON())
+    if (this.hasDraggedSelection === true) {
+      this.history.push(this.toJSON())
+    }
+    this.hasDraggedSelection = false
   }
 
   removeSelection() {

--- a/lib/src/layout/GraphLayout.ts
+++ b/lib/src/layout/GraphLayout.ts
@@ -2,14 +2,12 @@ import { Entity, Model, IEntityDatum } from '@alephdata/followthemoney'
 import { forceSimulation, forceLink, forceCollide } from 'd3-force';
 import { Vertex } from './Vertex'
 import { Edge } from './Edge'
-import { Viewport } from './Viewport'
 import { Point } from './Point';
 import { Rectangle } from './Rectangle';
 import { GraphConfig } from '../GraphConfig';
 import {History} from "./History";
 
 export interface IGraphLayoutData {
-  viewport: any
   entities: Array<IEntityDatum>
   vertices: Array<any>
   edges: Array<any>
@@ -24,7 +22,6 @@ export type GraphElement = Vertex | Edge
 export class GraphLayout {
   public readonly config: GraphConfig
   public readonly model: Model
-  viewport: Viewport;
   vertices = new Map<string, Vertex>()
   edges = new Map<string, Edge>()
   entities = new Map<string, Entity>()
@@ -36,7 +33,6 @@ export class GraphLayout {
   constructor(config: GraphConfig, model: Model) {
     this.config = config
     this.model = model
-    this.viewport = new Viewport(config)
     this.history = new History(this);
 
     this.addVertex = this.addVertex.bind(this)
@@ -287,7 +283,6 @@ export class GraphLayout {
 
   toJSON(): IGraphLayoutData {
     return {
-      viewport: this.viewport.toJSON(),
       entities: this.getEntities().map((entity) => entity.toJSON()),
       vertices: this.getVertices().map((vertex) => vertex.toJSON()),
       edges: this.getEdges().map((edge) => edge.toJSON()),
@@ -311,7 +306,6 @@ export class GraphLayout {
       layout.edges.set(edge.id, edge)
     })
     layout.generate()
-    layout.viewport = Viewport.fromJSON(config, layoutData.viewport)
     layout.selectionMode = layoutData.selectionMode
     layout.selection = layoutData.selection
     return layout

--- a/lib/src/layout/History.ts
+++ b/lib/src/layout/History.ts
@@ -38,6 +38,8 @@ export class History {
 
     this.state = nextState
     this.current = this.stack[this.state];
+    this.current.selection = []
+    this.current.selectionMode = false
     return this.layout.update(this.current)
   }
 

--- a/lib/src/renderer/GraphRenderer.tsx
+++ b/lib/src/renderer/GraphRenderer.tsx
@@ -23,9 +23,7 @@ export class GraphRenderer extends React.Component<IGraphContext> {
   }
 
   updateViewport(viewport: Viewport) {
-    const { layout } = this.props;
-    layout.viewport = viewport
-    this.props.updateLayout(layout)
+    this.props.updateViewport(viewport)
   }
 
   dragSelection(offset: Point) {
@@ -94,9 +92,9 @@ export class GraphRenderer extends React.Component<IGraphContext> {
   }
 
   render(){
-    const { layout } = this.props;
+    const { layout, viewport } = this.props;
     return (
-      <Canvas viewport={layout.viewport}
+      <Canvas viewport={viewport}
               selectArea={this.selectArea}
               selectionMode={layout.selectionMode}
               clearSelection={this.clearSelection}


### PR DESCRIPTION
#33 

Addresses 4 current inconsistencies in history state management:

- Selection of a graph element should not push to history stack, unless the element's position/attributes are changed
- When a vertex was added, undoing and redoing would place the vertex in an arbitrarily different position on the canvas, due to inconsistencies in the graph layout function => now vertex position will always remain the same when navigating through history stack
- Zooming, panning, and other viewport changes are stored and processed in an inconsistent way in when navigating the history stack => now viewport is no longer embedded within layout, but is instead its own standalone component
- Selection and selection mode are inconsistent when navigating the history stack -> selection and selection mode are now cleared when moving to another point in history
(Is this unexpected?  Would a user expect that their selection would be restored on undo/redo?)
